### PR TITLE
Fix: "Type instantiation is excessively deep and possibly infinite"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,11 @@ export function envChain(options: Parameters<typeof config>[0] = {
 					if (!descriptor || (descriptor.value === undefined && descriptor.set === undefined)) {
 						return acc;
 					}
+					if (typeof (this as any)[k].render === 'function') {
+						(acc as any)[k] = (this as any)[k]();
+					} else {
 						(acc as any)[k] = (this as any)[k];
+					}
 					return acc;
 				}, {})
 			};

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ export type Flatten<T> =
 	: T extends object
 	? { [K in keyof T]: Flatten<T[K]>; } : T;
 
-export type DefaultValue<ChainEnv> = 
-	string | ChainableEnv<ChainEnv> | ((v: string | undefined, ctx: ChainEnvWithoutOperators<ChainEnv>) => any) | undefined;
+export type DefaultValue<ChainEnv> =
+	string | ChainableEnv<ChainEnv> | ((v: string | undefined, ctx: Omit<Flatten<ChainEnv>, keyof ChainableEnvOperators<Flatten<ChainEnv>>>) => any) | undefined;
 
 type IncludeInChainWithFunction<
 	ChainEnv,
@@ -16,7 +16,7 @@ type IncludeInChainWithFunction<
 > = (K extends keyof ChainEnv ? Omit<ChainEnv, K> : ChainEnv) & {
 	[k in K]: V extends string ? string
 	: V extends ChainableEnv<infer R> ? ChainableEnv<Flatten<R>>
-	: V extends ((v: string | undefined, ctx: ChainEnvWithoutOperators<ChainEnv>) => infer R) ? R
+	: V extends ((v: string | undefined, ctx: Omit<Flatten<ChainEnv>, keyof ChainableEnvOperators<Flatten<ChainEnv>>>) => infer R) ? R
 	: V extends undefined ? string | undefined
 	: V;
 };
@@ -86,8 +86,12 @@ export type ChainableEnvOperators<ChainEnv = {}> = {
 	readonly clone: CloneOperator<ChainEnv>;
 };
 
-export type ChainEnvWithoutOperators<ChainEnv> = Omit<Flatten<ChainEnv>, keyof ChainableEnvOperators<Flatten<ChainEnv>>>;
-export type ChainableEnv<ChainEnv = {}> = ChainEnvWithoutOperators<ChainEnv> & ChainableEnvOperators<ChainEnv>;
+export type ChainableEnv<ChainEnv = {}> =
+	Omit<
+		Flatten<ChainEnv>, 
+		keyof ChainableEnvOperators<Flatten<ChainEnv>>
+	>
+	& ChainableEnvOperators<ChainEnv>;
 
 export function envChain(options: Parameters<typeof config>[0] = {
 	path: '.env',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,14 @@
 import { config } from 'dotenv';
 
-export type Flatten<T> =
+export type Flatten<T, Skip = undefined> =
 	T extends number
 	? T
 	: T extends object
-	? { [K in keyof T]: Flatten<T[K]>; } : T;
+	? {
+		[K in keyof T]: K extends keyof Skip
+		? T[K]
+		: Flatten<T[K]>;
+	} : T;
 
 export type DefaultValue<ctx> =
 	string | ChainableEnv<ctx> | ((v: string | undefined, ctx: Omit<Flatten<ctx>, keyof ChainableEnvOperators<Flatten<ctx>>>) => any) | undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,7 @@ export type Flatten<T> =
 	T extends number
 	? T
 	: T extends object
-	? T extends ChainableEnv<infer R>
-	? ChainableEnv<Flatten<R>>
-	: { [K in keyof T]: Flatten<T[K]>; } : T;
+	? { [K in keyof T]: Flatten<T[K]>; } : T;
 
 export type DefaultValue<ChainEnv> = 
 	string | ChainableEnv<ChainEnv> | ((v: string | undefined, ctx: ChainEnvWithoutOperators<ChainEnv>) => any) | undefined;


### PR DESCRIPTION
The recursion of certain types of the main operator lib caused an excessive type instantiation. 
This pull request resolves this issue by decoupling the flatten function from the need of the ChainableEnv operator.
Along with this refactor,the rename of certain types was necessary.  